### PR TITLE
ch03: generate documentation automatically

### DIFF
--- a/ch02/CMakeLists.txt
+++ b/ch02/CMakeLists.txt
@@ -16,7 +16,7 @@ include(CommonCompileFlags)
 find_package(Protobuf REQUIRED)
 find_package(PkgConfig REQUIRED)
 pkg_search_module(GRPCPP REQUIRED grpc++)
-find_program(GRPC_CPP_PLUGIN grpc_cpp_plugin)
+find_program(GRPC_CPP_PLUGIN grpc_cpp_plugin REQUIRED)
 
 get_filename_component(srv_proto "grpc/service.proto" ABSOLUTE)
 get_filename_component(srv_proto_path "${srv_proto}" PATH)

--- a/ch03/doc/CMakeLists.txt
+++ b/ch03/doc/CMakeLists.txt
@@ -24,7 +24,7 @@ find_package(Sphinx REQUIRED)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/conf.py.in
                ${CMAKE_CURRENT_BINARY_DIR}/conf.py @ONLY)
 add_custom_target(
-  sphinx-doc
+  sphinx-doc ALL
   COMMAND ${SPHINX_EXECUTABLE} -b html -c ${CMAKE_CURRENT_BINARY_DIR}
           ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
I used ALL to always generate documentation https://cmake.org/cmake/help/latest/command/add_custom_target.html

```
ALL Indicate that this target should be added to the default build target so that it will be run every time (the command cannot be called ALL).
```
Of course, documentation can be generated with these commands.
`cmake --build . --target doxygen-doc` or `cmake --build . --target sphinx-doc'