### PR TITLE
ch14 docker scratch

### DIFF
--- a/Chapter14/containers/docker/scratch.Dockerfile
+++ b/Chapter14/containers/docker/scratch.Dockerfile
@@ -1,5 +1,5 @@
 FROM scratch
 
 COPY customer /bin/customer
-
-CMD /bin/customer
+VOLUME /tmp
+CMD ["/bin/customer"]


### PR DESCRIPTION
Building a static executable file:
conan install .. --build=missing -s build_type=Release -pr=hosacpp
cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXE_LINKER_FLAGS="-static" -DBUILD_SHARED_LIBS=OFF -DCMAKE_FIND_LIBRARY_SUFFIXES=".a"
cmake --build .

Dockerfile:
VOLUME /tmp is for temporary files
CMD ["/bin/customer"] is to execute without /bin/sh that does not exist inside the Docker image