### PR TITLE
Fix pre-commit issue with merging PRs

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,4 +21,4 @@ jobs:
         path: ~/.cache/pre-commit
         key: pre-commit|${{ hashFiles('.pre-commit-config.yaml') }}
     - run: pip install pre-commit
-    - run: pre-commit run --all-files
+    - run: SKIP=no-commit-to-branch pre-commit run --all-files


### PR DESCRIPTION
When merging a PR to master pre-commit was failing because it though we're commiting to a forbidden branch. Disabling the check here allows pre-commit to pass while still performing the validation on dev environments.