### PR TITLE
Refresh environment, tools and README

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,9 @@ cache:
     - build
 
 default:
-  image: conanio/gcc10
+  # GCC 13 on U18 is not available.
+  # All images are listed at https://github.com/conan-io/conan-docker-tools/tree/master/modern#gcc
+  image: conanio/gcc13-ubuntu16.04
 
 stages:
   - prerequisites
@@ -19,24 +21,23 @@ before_script:
 prerequisites:
   stage: prerequisites
   script:
-    - pip install conan==1.34.1
+    - pip install -U 'conan<2' 'cmake>=3.27.9'
     - conan profile new default || true
     - conan profile update settings.compiler=gcc default
     - conan profile update settings.compiler.libcxx=libstdc++11 default
-    - conan profile update settings.compiler.version=10 default
+    - conan profile update settings.compiler.version=13 default
     - conan profile update settings.arch=x86_64 default
     - conan profile update settings.build_type=Release default
-    - conan profile update settings.os=Linux default
-    - conan remote add trompeloeil https://api.bintray.com/conan/trompeloeil/trompeloeil || true
+    - conan profile update settings.os=Linux default || true
 
 build:
   stage: build
   script:
-    - sudo apt-get update && sudo apt-get install -y docker.io
+    - sudo apt-get update && sudo apt-get install -y docker.io ninja-build
     - mkdir -p build
     - cd build
-    - conan install ../ch08/customer --build=missing
-    - cmake -DBUILD_TESTING=1 -DCMAKE_BUILD_TYPE=Release ../ch08/customer
+    - conan install ../Chapter08/customer --build=missing
+    - cmake -GNinja -DBUILD_TESTING=1 -DCMAKE_BUILD_TYPE=Release ../Chapter08/customer
     - cmake --build .
 
 test:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,8 +21,8 @@ repos:
         args: [--branch, master]
       - id: trailing-whitespace
         exclude: 3rd-parties/
-  - repo: https://github.com/pocc/pre-commit-hooks
-    rev: v1.3.5
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v17.0.6
     hooks:
       - id: clang-format
         args: [--style=Google, -i]

--- a/Chapter01/README.md
+++ b/Chapter01/README.md
@@ -7,7 +7,7 @@ Hands-On Software Architecture with C++ by Packt Publishing
 
 Install the following software:
 - CMake 3.15
-- GCC 10
+- GCC 13
 
 ### Building
 
@@ -20,9 +20,9 @@ cmake .. -DCMAKE_BUILD_TYPE=Release
 cmake --build .
 ```
 
-If GCC 10 is not your default compiler, you can tell CMake to use it with the `CMAKE_CXX_COMPILER` flag.
+If GCC 13 is not your default compiler, you can tell CMake to use it with the `CMAKE_CXX_COMPILER` flag.
 Replace the first invocation above with:
 
 ```bash
-cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=`which g++-10`
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=`which g++-13`
 ```

--- a/Chapter01/README.md
+++ b/Chapter01/README.md
@@ -1,5 +1,5 @@
-# Hands-On-Software-Architecture-with-Cpp
-Hands-On Software Architecture with C++ by Packt Publishing
+# Software Architecture with C++
+Software Architecture with C++ by Packt Publishing
 
 ## Chapter 1: Importance of Software Architecture and Principles of Great Design
 

--- a/Chapter02/CMakeLists.txt
+++ b/Chapter02/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
 
 list(APPEND CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}")
 
-find_package(ms-gsl CONFIG REQUIRED)
+find_package(Microsoft.GSL CONFIG REQUIRED)
 
 add_library(state INTERFACE)
 target_include_directories(state INTERFACE state/)

--- a/Chapter02/README.md
+++ b/Chapter02/README.md
@@ -9,8 +9,8 @@ Hands-On Software Architecture with C++ by Packt Publishing
 Install the following software:
 
 - CMake 3.15
-- Conan 1.34.1
-- GCC 10
+- Conan 1.62.0
+- GCC 13
 
 Assuming you're on Linux or using WSL, configure a hosacpp Conan profile and remotes by running:
 
@@ -18,16 +18,16 @@ Assuming you're on Linux or using WSL, configure a hosacpp Conan profile and rem
 conan profile new hosacpp || true
 conan profile update settings.compiler=gcc hosacpp
 conan profile update settings.compiler.libcxx=libstdc++11 hosacpp
-conan profile update settings.compiler.version=10 hosacpp
+conan profile update settings.compiler.version=13 hosacpp
 conan profile update settings.arch=x86_64 hosacpp
 conan profile update settings.os=Linux hosacpp
 ```
 
-If GCC 10 is not your default compiler, you also need to add:
+If GCC 13 is not your default compiler, you also need to add:
 
 ```bash
-conan profile update env.CXX=`which g++-10` hosacpp
-conan profile update env.CC=`which gcc-10` hosacpp
+conan profile update env.CXX=`which g++-13` hosacpp
+conan profile update env.CC=`which gcc-13` hosacpp
 ```
 
 ### Building
@@ -42,9 +42,9 @@ cmake .. -DCMAKE_BUILD_TYPE=Release # build type must match Conan's
 cmake --build .
 ```
 
-If GCC 10 is not your default compiler, you can tell CMake to use it with the `CMAKE_CXX_COMPILER` flag.
+If GCC 13 is not your default compiler, you can tell CMake to use it with the `CMAKE_CXX_COMPILER` flag.
 Replace the first invocation above with:
 
 ```bash
-cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=`which g++-10`
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=`which g++-13`
 ```

--- a/Chapter02/README.md
+++ b/Chapter02/README.md
@@ -1,6 +1,6 @@
-# Hands-On-Software-Architecture-with-Cpp
+# Software Architecture with C++
 
-Hands-On Software Architecture with C++ by Packt Publishing
+Software Architecture with C++ by Packt Publishing
 
 ## Chapter 2: Architectural Styles
 
@@ -12,22 +12,22 @@ Install the following software:
 - Conan 1.62.0
 - GCC 13
 
-Assuming you're on Linux or using WSL, configure a hosacpp Conan profile and remotes by running:
+Assuming you're on Linux or using WSL, configure a sacpp Conan profile and remotes by running:
 
 ```bash
-conan profile new hosacpp || true
-conan profile update settings.compiler=gcc hosacpp
-conan profile update settings.compiler.libcxx=libstdc++11 hosacpp
-conan profile update settings.compiler.version=13 hosacpp
-conan profile update settings.arch=x86_64 hosacpp
-conan profile update settings.os=Linux hosacpp
+conan profile new sacpp || true
+conan profile update settings.compiler=gcc sacpp
+conan profile update settings.compiler.libcxx=libstdc++11 sacpp
+conan profile update settings.compiler.version=13 sacpp
+conan profile update settings.arch=x86_64 sacpp
+conan profile update settings.os=Linux sacpp
 ```
 
 If GCC 13 is not your default compiler, you also need to add:
 
 ```bash
-conan profile update env.CXX=`which g++-13` hosacpp
-conan profile update env.CC=`which gcc-13` hosacpp
+conan profile update env.CXX=`which g++-13` sacpp
+conan profile update env.CC=`which gcc-13` sacpp
 ```
 
 ### Building
@@ -37,7 +37,7 @@ To build the project, first cd to its directory, and then run:
 ```bash
 mkdir build
 cd build
-conan install .. --build=missing -s build_type=Release -pr=hosacpp
+conan install .. --build=missing -s build_type=Release -pr=sacpp
 cmake .. -DCMAKE_BUILD_TYPE=Release # build type must match Conan's
 cmake --build .
 ```

--- a/Chapter02/conanfile.txt
+++ b/Chapter02/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-ms-gsl/3.1.0
+ms-gsl/4.0.0
 
 [generators]
 CMakeDeps

--- a/Chapter03/README.md
+++ b/Chapter03/README.md
@@ -1,5 +1,5 @@
-# Hands-On-Software-Architecture-with-Cpp
-Hands-On Software Architecture with C++ by Packt Publishing
+# Software Architecture with C++
+Software Architecture with C++ by Packt Publishing
 
 ## Chapter 3: Functional and Nonfunctional Requirements
 

--- a/Chapter04/README.md
+++ b/Chapter04/README.md
@@ -1,6 +1,6 @@
-# Hands-On-Software-Architecture-with-Cpp
+# Software Architecture with C++
 
-Hands-On Software Architecture with C++ by Packt Publishing
+Software Architecture with C++ by Packt Publishing
 
 ## Chapter 4: Architectural and System Design Patterns
 

--- a/Chapter05/README.md
+++ b/Chapter05/README.md
@@ -6,14 +6,10 @@ Hands-On Software Architecture with C++ by Packt Publishing
 ### Prerequisites
 
 Install the following software:
-- CMake 3.15
-- GCC 11
-
-Install the following software:
 
 - CMake 3.15
-- Conan 1.34.1
-- GCC 11
+- Conan 1.62.0
+- GCC 13
 
 Assuming you're on Linux or using WSL, configure a hosacpp Conan profile and remotes by running:
 
@@ -26,11 +22,11 @@ conan profile update settings.arch=x86_64 hosacpp
 conan profile update settings.os=Linux hosacpp
 ```
 
-If GCC 11 is not your default compiler, you also need to add:
+If GCC 13 is not your default compiler, you also need to add:
 
 ```bash
-conan profile update env.CXX=`which g++-11` hosacpp
-conan profile update env.CC=`which gcc-11` hosacpp
+conan profile update env.CXX=`which g++-13` hosacpp
+conan profile update env.CC=`which gcc-13` hosacpp
 ```
 
 ### Building
@@ -49,5 +45,5 @@ If GCC is not your default compiler, you can tell CMake to use it with the `CMAK
 Replace the first invocation above with:
 
 ```bash
-cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=`which g++-11`
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=`which g++-13`
 ```

--- a/Chapter05/README.md
+++ b/Chapter05/README.md
@@ -1,5 +1,5 @@
-# Hands-On-Software-Architecture-with-Cpp
-Hands-On Software Architecture with C++ by Packt Publishing
+# Software Architecture with C++
+Software Architecture with C++ by Packt Publishing
 
 ## Chapter 5: Leveraging C++ Language Features
 
@@ -11,22 +11,22 @@ Install the following software:
 - Conan 1.62.0
 - GCC 13
 
-Assuming you're on Linux or using WSL, configure a hosacpp Conan profile and remotes by running:
+Assuming you're on Linux or using WSL, configure a sacpp Conan profile and remotes by running:
 
 ```bash
-conan profile new hosacpp || true
-conan profile update settings.compiler=gcc hosacpp
-conan profile update settings.compiler.libcxx=libstdc++11 hosacpp
-conan profile update settings.compiler.version=11 hosacpp
-conan profile update settings.arch=x86_64 hosacpp
-conan profile update settings.os=Linux hosacpp
+conan profile new sacpp || true
+conan profile update settings.compiler=gcc sacpp
+conan profile update settings.compiler.libcxx=libstdc++11 sacpp
+conan profile update settings.compiler.version=11 sacpp
+conan profile update settings.arch=x86_64 sacpp
+conan profile update settings.os=Linux sacpp
 ```
 
 If GCC 13 is not your default compiler, you also need to add:
 
 ```bash
-conan profile update env.CXX=`which g++-13` hosacpp
-conan profile update env.CC=`which gcc-13` hosacpp
+conan profile update env.CXX=`which g++-13` sacpp
+conan profile update env.CC=`which gcc-13` sacpp
 ```
 
 ### Building
@@ -36,7 +36,7 @@ To build the project, first cd to its directory, and then run:
 ```bash
 mkdir build
 cd build
-conan install .. --build=missing -s build_type=Release -pr=hosacpp
+conan install .. --build=missing -s build_type=Release -pr=sacpp
 cmake .. -DCMAKE_BUILD_TYPE=Release # build type must match Conan's
 cmake --build .
 ```

--- a/Chapter05/conanfile.txt
+++ b/Chapter05/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-ms-gsl/3.1.0
+ms-gsl/4.0.0
 
 [generators]
 CMakeDeps

--- a/Chapter05/src/1_base.cpp
+++ b/Chapter05/src/1_base.cpp
@@ -6,6 +6,7 @@
 #include <optional>
 #include <ostream>
 #include <ranges>
+#include <unordered_map>
 #include <vector>
 
 using CustomerId = int;

--- a/Chapter05/src/1_base.cpp
+++ b/Chapter05/src/1_base.cpp
@@ -28,7 +28,7 @@ struct Item {
   bool featured{};
 };
 
-std::ostream &operator<<(std::ostream &os, const Item* item) {
+std::ostream &operator<<(std::ostream &os, const Item *item) {
   auto stringify_optional = [](const auto &optional) {
     using optional_value_type =
         typename std::remove_cvref_t<decltype(optional)>::value_type;

--- a/Chapter05/src/2_ranges_part_1.cpp
+++ b/Chapter05/src/2_ranges_part_1.cpp
@@ -29,7 +29,7 @@ struct Item {
   bool featured{};
 };
 
-std::ostream &operator<<(std::ostream &os, const Item* item) {
+std::ostream &operator<<(std::ostream &os, const Item *item) {
   auto stringify_optional = [](const auto &optional) {
     using optional_value_type =
         typename std::remove_cvref_t<decltype(optional)>::value_type;

--- a/Chapter05/src/2_ranges_part_1.cpp
+++ b/Chapter05/src/2_ranges_part_1.cpp
@@ -6,6 +6,7 @@
 #include <optional>
 #include <ostream>
 #include <ranges>
+#include <unordered_map>
 #include <vector>
 
 using namespace std::chrono;

--- a/Chapter05/src/3_ranges_part_2.cpp
+++ b/Chapter05/src/3_ranges_part_2.cpp
@@ -29,7 +29,7 @@ struct Item {
   bool featured{};
 };
 
-std::ostream &operator<<(std::ostream &os, const Item* item) {
+std::ostream &operator<<(std::ostream &os, const Item *item) {
   auto stringify_optional = [](const auto &optional) {
     using optional_value_type =
         typename std::remove_cvref_t<decltype(optional)>::value_type;

--- a/Chapter05/src/3_ranges_part_2.cpp
+++ b/Chapter05/src/3_ranges_part_2.cpp
@@ -6,6 +6,7 @@
 #include <optional>
 #include <ostream>
 #include <ranges>
+#include <unordered_map>
 #include <vector>
 
 using namespace std::chrono;

--- a/Chapter05/src/4_concepts.cpp
+++ b/Chapter05/src/4_concepts.cpp
@@ -29,7 +29,7 @@ struct Item {
   bool featured{};
 };
 
-std::ostream &operator<<(std::ostream &os, const Item* item) {
+std::ostream &operator<<(std::ostream &os, const Item *item) {
   auto stringify_optional = [](const auto &optional) {
     using optional_value_type =
         typename std::remove_cvref_t<decltype(optional)>::value_type;
@@ -134,8 +134,8 @@ void order_items_by_date_added(
 }
 
 template <input_range Container>
-requires std::is_same_v<typename Container::value_type,
-                        gsl::not_null<const Item *>>
+  requires std::is_same_v<typename Container::value_type,
+                          gsl::not_null<const Item *>>
 void render_item_gallery(const Container &items) {
   copy(items,
        std::ostream_iterator<typename Container::value_type>(std::cout, "\n"));

--- a/Chapter05/src/4_concepts.cpp
+++ b/Chapter05/src/4_concepts.cpp
@@ -6,6 +6,7 @@
 #include <optional>
 #include <ostream>
 #include <ranges>
+#include <unordered_map>
 #include <vector>
 
 using namespace std::chrono;

--- a/Chapter05/src/5_modules/main.cpp
+++ b/Chapter05/src/5_modules/main.cpp
@@ -80,7 +80,7 @@ void order_items_by_date_added(
 }
 
 template <input_range Container>
-requires std::is_same_v<typename Container::value_type, const Item *>
+  requires std::is_same_v<typename Container::value_type, const Item *>
 void render_item_gallery(const Container &items) {
   auto printable_items =
       items |

--- a/Chapter06/01_raii_guards.cpp
+++ b/Chapter06/01_raii_guards.cpp
@@ -1,5 +1,5 @@
 #include <chrono>
-#include <gsl/gsl_util>
+#include <gsl/util>
 #include <iostream>
 #include <ostream>
 

--- a/Chapter06/05_niebloids.cpp
+++ b/Chapter06/05_niebloids.cpp
@@ -10,20 +10,21 @@ namespace detail {
 struct contains_fn final {
   template <std::input_iterator It, std::sentinel_for<It> Sent, typename T,
             typename Proj = std::identity>
-  requires std::indirect_binary_predicate < std::ranges::equal_to,
-      std::projected<It, Proj>,
-  const T * > constexpr bool operator()(It first, Sent last, const T &value,
-                                        Proj projection = {}) const {
+    requires std::indirect_binary_predicate<std::ranges::equal_to,
+                                            std::projected<It, Proj>, const T *>
+  constexpr bool operator()(It first, Sent last, const T &value,
+                            Proj projection = {}) const {
     while (first != last && std::invoke(projection, *first) != value) ++first;
     return first != last;
   }
 
   template <std::ranges::input_range Range, typename T,
             typename Proj = std::identity>
-  requires std::indirect_binary_predicate < std::ranges::equal_to,
-      std::projected<std::ranges::iterator_t<Range>, Proj>,
-  const T * > constexpr bool operator()(Range &&range, const T &value,
-                                        Proj projection = {}) const {
+    requires std::indirect_binary_predicate<
+        std::ranges::equal_to,
+        std::projected<std::ranges::iterator_t<Range>, Proj>, const T *>
+  constexpr bool operator()(Range &&range, const T &value,
+                            Proj projection = {}) const {
     return (*this)(std::ranges::begin(range), std::ranges::end(range), value,
                    std::move(projection));
   }

--- a/Chapter06/05_niebloids.cpp
+++ b/Chapter06/05_niebloids.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <deque>
+#include <functional>
 #include <gsl/pointers>
 #include <iostream>
 #include <ostream>

--- a/Chapter06/06_policy-based_design.cpp
+++ b/Chapter06/06_policy-based_design.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <iostream>
 #include <string_view>
+#include <utility>
 
 struct NullPrintingPolicy {
   template <typename... Args>

--- a/Chapter06/07_static_polymorphism.cpp
+++ b/Chapter06/07_static_polymorphism.cpp
@@ -34,7 +34,7 @@ using GlamorousVariant = std::variant<PinkHeels, GoldenWatch>;
 class CommonGlamorousItem {
  public:
   template <typename T>
-  requires std::is_base_of_v<GlamorousItem<T>, T>
+    requires std::is_base_of_v<GlamorousItem<T>, T>
   explicit CommonGlamorousItem(T&& item) : item_{std::forward<T>(item)} {}
 
   void appear_in_full_glory() {

--- a/Chapter06/12_state_and_visitation.cpp
+++ b/Chapter06/12_state_and_visitation.cpp
@@ -62,48 +62,47 @@ class ItemStateMachine {
   template <typename Event>
   void process_event(Event &&event) {
     state_ = std::visit(overload{
-        [&](const auto &state) requires std::is_same_v<
-            decltype(on_event(state, std::forward<Event>(event))), State> {
-          return on_event(state, std::forward<Event>(event));
+        [&](const auto &state)
+          requires std::is_same_v<decltype(on_event(
+                                      state, std::forward<Event>(event))),
+                                  State>
+        { return on_event(state, std::forward<Event>(event)); },
+        [](const auto &unsupported_state) -> State {
+          throw std::logic_error{"Unsupported state transition"};
+        }},
+        state_);
   }
-  , [](const auto &unsupported_state) -> State {
-    throw std::logic_error{"Unsupported state transition"};
+
+  std::string report_current_state() {
+    return std::visit(
+        overload{[](const state::Available &state) -> std::string {
+                   return std::to_string(state.count) + " items available";
+                 },
+                 [](const state::Depleted) -> std::string {
+                   return "Item is temporarily out of stock";
+                 },
+                 [](const state::Discontinued) -> std::string {
+                   return "Item has been discontinued";
+                 }},
+        state_);
   }
-      },
-      state_);
-      }
 
-      std::string report_current_state() {
-        return std::visit(
-            overload{[](const state::Available &state) -> std::string {
-                       return std::to_string(state.count) + " items available";
-                     },
-                     [](const state::Depleted) -> std::string {
-                       return "Item is temporarily out of stock";
-                     },
-                     [](const state::Discontinued) -> std::string {
-                       return "Item has been discontinued";
-                     }},
-            state_);
-      }
+ private:
+  State state_;
+};
 
-     private:
-      State state_;
-      }
-      ;
-
-      int main() {
-        auto fsm = ItemStateMachine{};
-        std::cout << fsm.report_current_state() << '\n';
-        fsm.process_event(event::DeliveryArrived{3});
-        std::cout << fsm.report_current_state() << '\n';
-        fsm.process_event(event::Purchased{2});
-        std::cout << fsm.report_current_state() << '\n';
-        fsm.process_event(event::DeliveryArrived{2});
-        std::cout << fsm.report_current_state() << '\n';
-        fsm.process_event(event::Purchased{3});
-        std::cout << fsm.report_current_state() << '\n';
-        fsm.process_event(event::Discontinued{});
-        std::cout << fsm.report_current_state() << '\n';
-        // fsm.process_event(event::DeliveryArrived{1});
-      }
+int main() {
+  auto fsm = ItemStateMachine{};
+  std::cout << fsm.report_current_state() << '\n';
+  fsm.process_event(event::DeliveryArrived{3});
+  std::cout << fsm.report_current_state() << '\n';
+  fsm.process_event(event::Purchased{2});
+  std::cout << fsm.report_current_state() << '\n';
+  fsm.process_event(event::DeliveryArrived{2});
+  std::cout << fsm.report_current_state() << '\n';
+  fsm.process_event(event::Purchased{3});
+  std::cout << fsm.report_current_state() << '\n';
+  fsm.process_event(event::Discontinued{});
+  std::cout << fsm.report_current_state() << '\n';
+  // fsm.process_event(event::DeliveryArrived{1});
+}

--- a/Chapter06/13_memory_arenas.cpp
+++ b/Chapter06/13_memory_arenas.cpp
@@ -1,8 +1,10 @@
 #include <algorithm>
+#include <array>
 #include <iomanip>
 #include <iostream>
 #include <memory_resource>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 void using_memory_arenas() {

--- a/Chapter06/README.md
+++ b/Chapter06/README.md
@@ -1,5 +1,5 @@
-# Hands-On-Software-Architecture-with-Cpp
-Hands-On Software Architecture with C++ by Packt Publishing
+# Software Architecture with C++
+Software Architecture with C++ by Packt Publishing
 
 ## Chapter 6: Design Patterns and C++
 
@@ -10,22 +10,22 @@ Install the following software:
 - Conan 1.62.0
 - GCC 13
 
-Assuming you're on Linux or using WSL, configure a hosacpp Conan profile and remotes by running:
+Assuming you're on Linux or using WSL, configure a sacpp Conan profile and remotes by running:
 
 ```bash
-conan profile new hosacpp || true
-conan profile update settings.compiler=gcc hosacpp
-conan profile update settings.compiler.libcxx=libstdc++11 hosacpp
-conan profile update settings.compiler.version=13 hosacpp
-conan profile update settings.arch=x86_64 hosacpp
-conan profile update settings.os=Linux hosacpp
+conan profile new sacpp || true
+conan profile update settings.compiler=gcc sacpp
+conan profile update settings.compiler.libcxx=libstdc++11 sacpp
+conan profile update settings.compiler.version=13 sacpp
+conan profile update settings.arch=x86_64 sacpp
+conan profile update settings.os=Linux sacpp
 ```
 
 If GCC 13 is not your default compiler, you also need to add:
 
 ```bash
-conan profile update env.CXX=`which g++-13` hosacpp
-conan profile update env.CC=`which gcc-13` hosacpp
+conan profile update env.CXX=`which g++-13` sacpp
+conan profile update env.CC=`which gcc-13` sacpp
 ```
 
 ### Building
@@ -35,7 +35,7 @@ To build the project, first cd to its directory, and then run:
 ```bash
 mkdir build
 cd build
-conan install .. --build=missing -s build_type=Release -pr=hosacpp
+conan install .. --build=missing -s build_type=Release -pr=sacpp
 cmake .. -DCMAKE_BUILD_TYPE=Release # build type must match Conan's
 cmake --build .
 ```

--- a/Chapter06/README.md
+++ b/Chapter06/README.md
@@ -7,8 +7,8 @@ Hands-On Software Architecture with C++ by Packt Publishing
 
 Install the following software:
 - CMake 3.15
-- Conan 1.34.1
-- GCC 10
+- Conan 1.62.0
+- GCC 13
 
 Assuming you're on Linux or using WSL, configure a hosacpp Conan profile and remotes by running:
 
@@ -16,16 +16,16 @@ Assuming you're on Linux or using WSL, configure a hosacpp Conan profile and rem
 conan profile new hosacpp || true
 conan profile update settings.compiler=gcc hosacpp
 conan profile update settings.compiler.libcxx=libstdc++11 hosacpp
-conan profile update settings.compiler.version=10 hosacpp
+conan profile update settings.compiler.version=13 hosacpp
 conan profile update settings.arch=x86_64 hosacpp
 conan profile update settings.os=Linux hosacpp
 ```
 
-If GCC 10 is not your default compiler, you also need to add:
+If GCC 13 is not your default compiler, you also need to add:
 
 ```bash
-conan profile update env.CXX=`which g++-10` hosacpp
-conan profile update env.CC=`which gcc-10` hosacpp
+conan profile update env.CXX=`which g++-13` hosacpp
+conan profile update env.CC=`which gcc-13` hosacpp
 ```
 
 ### Building
@@ -40,9 +40,9 @@ cmake .. -DCMAKE_BUILD_TYPE=Release # build type must match Conan's
 cmake --build .
 ```
 
-If GCC 10 is not your default compiler, you can tell CMake to use it with the `CMAKE_CXX_COMPILER` flag.
+If GCC 13 is not your default compiler, you can tell CMake to use it with the `CMAKE_CXX_COMPILER` flag.
 Replace the first invocation above with:
 
 ```bash
-cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=`which g++-10`
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=`which g++-13`
 ```

--- a/Chapter06/conanfile.txt
+++ b/Chapter06/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-ms-gsl/3.1.0
+ms-gsl/4.0.0
 
 [generators]
 CMakeDeps

--- a/Chapter07/README.md
+++ b/Chapter07/README.md
@@ -7,8 +7,8 @@ Hands-On Software Architecture with C++ by Packt Publishing
 
 Install the following software:
 - CMake 3.15
-- Conan 1.34.1
-- GCC 10
+- Conan 1.62.0
+- GCC 13
 
 Assuming you're on Linux or using WSL, configure a hosacpp Conan profile and remotes by running:
 
@@ -16,16 +16,16 @@ Assuming you're on Linux or using WSL, configure a hosacpp Conan profile and rem
 conan profile new hosacpp || true
 conan profile update settings.compiler=gcc hosacpp
 conan profile update settings.compiler.libcxx=libstdc++11 hosacpp
-conan profile update settings.compiler.version=10 hosacpp
+conan profile update settings.compiler.version=13 hosacpp
 conan profile update settings.arch=x86_64 hosacpp
 conan profile update settings.os=Linux hosacpp
 ```
 
-If GCC 10 is not your default compiler, you also need to add:
+If GCC 13 is not your default compiler, you also need to add:
 
 ```bash
-conan profile update env.CXX=`which g++-10` hosacpp
-conan profile update env.CC=`which gcc-10` hosacpp
+conan profile update env.CXX=`which g++-13` hosacpp
+conan profile update env.CC=`which gcc-13` hosacpp
 ```
 
 ### Building
@@ -40,11 +40,11 @@ cmake .. -DCMAKE_BUILD_TYPE=Release # build type must match Conan's
 cmake --build .
 ```
 
-If GCC 10 is not your default compiler, you can tell CMake to use it with the `CMAKE_CXX_COMPILER` flag.
+If GCC 13 is not your default compiler, you can tell CMake to use it with the `CMAKE_CXX_COMPILER` flag.
 Replace the first invocation above with:
 
 ```bash
-cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=`which g++-10`
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=`which g++-13`
 ```
 
 

--- a/Chapter07/README.md
+++ b/Chapter07/README.md
@@ -1,5 +1,5 @@
-# Hands-On-Software-Architecture-with-Cpp
-Hands-On Software Architecture with C++ by Packt Publishing
+# Software Architecture with C++
+Software Architecture with C++ by Packt Publishing
 
 ## Chapter 7: Building and Packaging
 
@@ -10,22 +10,22 @@ Install the following software:
 - Conan 1.62.0
 - GCC 13
 
-Assuming you're on Linux or using WSL, configure a hosacpp Conan profile and remotes by running:
+Assuming you're on Linux or using WSL, configure a sacpp Conan profile and remotes by running:
 
 ```bash
-conan profile new hosacpp || true
-conan profile update settings.compiler=gcc hosacpp
-conan profile update settings.compiler.libcxx=libstdc++11 hosacpp
-conan profile update settings.compiler.version=13 hosacpp
-conan profile update settings.arch=x86_64 hosacpp
-conan profile update settings.os=Linux hosacpp
+conan profile new sacpp || true
+conan profile update settings.compiler=gcc sacpp
+conan profile update settings.compiler.libcxx=libstdc++11 sacpp
+conan profile update settings.compiler.version=13 sacpp
+conan profile update settings.arch=x86_64 sacpp
+conan profile update settings.os=Linux sacpp
 ```
 
 If GCC 13 is not your default compiler, you also need to add:
 
 ```bash
-conan profile update env.CXX=`which g++-13` hosacpp
-conan profile update env.CC=`which gcc-13` hosacpp
+conan profile update env.CXX=`which g++-13` sacpp
+conan profile update env.CC=`which gcc-13` sacpp
 ```
 
 ### Building
@@ -35,7 +35,7 @@ To build the customer project, first cd to its source directory, and then run:
 ```bash
 mkdir build
 cd build
-conan install .. --build=missing -s build_type=Release -pr=hosacpp
+conan install .. --build=missing -s build_type=Release -pr=sacpp
 cmake .. -DCMAKE_BUILD_TYPE=Release # build type must match Conan's
 cmake --build .
 ```

--- a/Chapter07/customer/README.md
+++ b/Chapter07/customer/README.md
@@ -1,5 +1,5 @@
-# Hands-On-Software-Architecture-with-Cpp
-Hands-On Software Architecture with C++ by Packt Publishing
+# Software Architecture with C++
+Software Architecture with C++ by Packt Publishing
 
 For building instructions, refer to the README file in the root of this chapter's code.
 

--- a/Chapter07/customer/conan/conanfile.py.in
+++ b/Chapter07/customer/conan/conanfile.py.in
@@ -8,7 +8,7 @@ class CustomerConan(ConanFile):
     license = "MIT"
     author = "Authors"
     homepage = "https://example.com"
-    url = "https://github.com/PacktPublishing/Hands-On-Software-Architecture-with-Cpp/"
+    url = "https://github.com/PacktPublishing/Software-Architecture-with-Cpp/"
     description = "Library and app for the Customer microservice"
     topics = ("Customer", "domifair")
     settings = "os", "compiler", "build_type", "arch"

--- a/Chapter07/customer/src/customer/CMakeLists.txt
+++ b/Chapter07/customer/src/customer/CMakeLists.txt
@@ -115,6 +115,6 @@ add_custom_target(
   COMMAND
     ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/conan/test_package/
     ${CMAKE_CURRENT_BINARY_DIR}/conan/test_package
-  COMMAND conan create . customer/testing -s build_type=$<CONFIG> -pr hosacpp
+  COMMAND conan create . customer/testing -s build_type=$<CONFIG> -pr sacpp
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/conan
   VERBATIM)

--- a/Chapter08/README.md
+++ b/Chapter08/README.md
@@ -7,8 +7,8 @@ Hands-On Software Architecture with C++ by Packt Publishing
 
 Install the following software:
 - CMake 3.15
-- Conan 1.34.1
-- GCC 10
+- Conan 1.62.0
+- GCC 13
 
 Assuming you're on Linux or using WSL, configure a hosacpp Conan profile and remotes by running:
 
@@ -16,16 +16,16 @@ Assuming you're on Linux or using WSL, configure a hosacpp Conan profile and rem
 conan profile new hosacpp || true
 conan profile update settings.compiler=gcc hosacpp
 conan profile update settings.compiler.libcxx=libstdc++11 hosacpp
-conan profile update settings.compiler.version=10 hosacpp
+conan profile update settings.compiler.version=13 hosacpp
 conan profile update settings.arch=x86_64 hosacpp
 conan profile update settings.os=Linux hosacpp
 ```
 
-If GCC 10 is not your default compiler, you also need to add:
+If GCC 13 is not your default compiler, you also need to add:
 
 ```bash
-conan profile update env.CXX=`which g++-10` hosacpp
-conan profile update env.CC=`which gcc-10` hosacpp
+conan profile update env.CXX=`which g++-13` hosacpp
+conan profile update env.CC=`which gcc-13` hosacpp
 ```
 
 ### Building
@@ -42,11 +42,11 @@ cmake .. -DCMAKE_BUILD_TYPE=Release # build type must match Conan's
 cmake --build .
 ```
 
-If GCC 10 is not your default compiler, you can tell CMake to use it with the `CMAKE_CXX_COMPILER` flag.
+If GCC 13 is not your default compiler, you can tell CMake to use it with the `CMAKE_CXX_COMPILER` flag.
 Replace the first invocation above with:
 
 ```bash
-cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=`which g++-10`
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=`which g++-13`
 ```
 
 ### Testing

--- a/Chapter08/README.md
+++ b/Chapter08/README.md
@@ -1,5 +1,5 @@
-# Hands-On-Software-Architecture-with-Cpp
-Hands-On Software Architecture with C++ by Packt Publishing
+# Software Architecture with C++
+Software Architecture with C++ by Packt Publishing
 
 ## Chapter 8: Writing Testable Code
 
@@ -10,22 +10,22 @@ Install the following software:
 - Conan 1.62.0
 - GCC 13
 
-Assuming you're on Linux or using WSL, configure a hosacpp Conan profile and remotes by running:
+Assuming you're on Linux or using WSL, configure a sacpp Conan profile and remotes by running:
 
 ```bash
-conan profile new hosacpp || true
-conan profile update settings.compiler=gcc hosacpp
-conan profile update settings.compiler.libcxx=libstdc++11 hosacpp
-conan profile update settings.compiler.version=13 hosacpp
-conan profile update settings.arch=x86_64 hosacpp
-conan profile update settings.os=Linux hosacpp
+conan profile new sacpp || true
+conan profile update settings.compiler=gcc sacpp
+conan profile update settings.compiler.libcxx=libstdc++11 sacpp
+conan profile update settings.compiler.version=13 sacpp
+conan profile update settings.arch=x86_64 sacpp
+conan profile update settings.os=Linux sacpp
 ```
 
 If GCC 13 is not your default compiler, you also need to add:
 
 ```bash
-conan profile update env.CXX=`which g++-13` hosacpp
-conan profile update env.CC=`which gcc-13` hosacpp
+conan profile update env.CXX=`which g++-13` sacpp
+conan profile update env.CC=`which gcc-13` sacpp
 ```
 
 ### Building
@@ -37,7 +37,7 @@ To build each of them, first cd to their source directory, and then run:
 ```bash
 mkdir build
 cd build
-conan install .. --build=missing -s build_type=Release -pr=hosacpp
+conan install .. --build=missing -s build_type=Release -pr=sacpp
 cmake .. -DCMAKE_BUILD_TYPE=Release # build type must match Conan's
 cmake --build .
 ```

--- a/Chapter08/customer/README.md
+++ b/Chapter08/customer/README.md
@@ -1,5 +1,5 @@
-# Hands-On-Software-Architecture-with-Cpp
-Hands-On Software Architecture with C++ by Packt Publishing
+# Software Architecture with C++
+Software Architecture with C++ by Packt Publishing
 
 For building instructions, refer to the README file in the root of this chapter's code.
 

--- a/Chapter08/customer/conan/conanfile.py.in
+++ b/Chapter08/customer/conan/conanfile.py.in
@@ -8,7 +8,7 @@ class CustomerConan(ConanFile):
     license = "MIT"
     author = "Authors"
     homepage = "https://example.com"
-    url = "https://github.com/PacktPublishing/Hands-On-Software-Architecture-with-Cpp/"
+    url = "https://github.com/PacktPublishing/Software-Architecture-with-Cpp/"
     description = "Library and app for the Customer microservice"
     topics = ("Customer", "domifair")
     settings = "os", "compiler", "build_type", "arch"

--- a/Chapter08/customer/conanfile.txt
+++ b/Chapter08/customer/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
 cpprestsdk/2.10.18
-Catch2/2.11.1@catchorg/stable
+catch2/2.13.10
 doctest/2.3.7
 
 [generators]

--- a/Chapter08/customer/src/customer/CMakeLists.txt
+++ b/Chapter08/customer/src/customer/CMakeLists.txt
@@ -115,6 +115,6 @@ add_custom_target(
   COMMAND
     ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/conan/test_package/
     ${CMAKE_CURRENT_BINARY_DIR}/conan/test_package
-  COMMAND conan create . customer/testing -s build_type=$<CONFIG> -pr hosacpp
+  COMMAND conan create . customer/testing -s build_type=$<CONFIG> -pr sacpp
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/conan
   VERBATIM)

--- a/Chapter08/customer/test/CMakeLists.txt
+++ b/Chapter08/customer/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(lib/cmake/Catch2/Catch)
+include(Catch)
 
 include(FetchGTest)
 include(GoogleTest)

--- a/Chapter08/mobile_app/conanfile.txt
+++ b/Chapter08/mobile_app/conanfile.txt
@@ -1,7 +1,7 @@
 [requires]
-Catch2/2.11.0@catchorg/stable
-trompeloeil/v37@rollbear/stable
-ms-gsl/3.1.0
+catch2/2.13.10
+trompeloeil/46
+ms-gsl/4.0.0
 
 [generators]
 CMakeDeps

--- a/Chapter08/mobile_app/src/merchants/reviews.cpp
+++ b/Chapter08/mobile_app/src/merchants/reviews.cpp
@@ -2,6 +2,7 @@
 
 #include <gsl/gsl>
 #include <ranges>
+#include <vector>
 
 template <typename T>
 constexpr bool is_range_of_reviews_v =

--- a/Chapter08/mobile_app/test/CMakeLists.txt
+++ b/Chapter08/mobile_app/test/CMakeLists.txt
@@ -1,4 +1,4 @@
 include(FetchGTest)
 include(GoogleTest)
-include(lib/cmake/Catch2/Catch)
+include(Catch)
 add_subdirectory(merchants)

--- a/Chapter09/README.md
+++ b/Chapter09/README.md
@@ -1,5 +1,5 @@
-# Hands-On-Software-Architecture-with-Cpp
-Hands-On Software Architecture with C++ by Packt Publishing
+# Software Architecture with C++
+Software Architecture with C++ by Packt Publishing
 
 ## Chapter 9: Continuous Integration and Continuous Deployment
 

--- a/Chapter09/gitlab-ci.yml
+++ b/Chapter09/gitlab-ci.yml
@@ -19,11 +19,11 @@ before_script:
 prerequisites:
   stage: prerequisites
   script:
-    - pip install conan==1.34.1
+    - pip install conan==1.62.0
     - conan profile new default || true
     - conan profile update settings.compiler=gcc default
     - conan profile update settings.compiler.libcxx=libstdc++11 default
-    - conan profile update settings.compiler.version=10 default
+    - conan profile update settings.compiler.version=13 default
     - conan profile update settings.arch=x86_64 default
     - conan profile update settings.build_type=Release default
     - conan profile update settings.os=Linux default

--- a/Chapter09/packer/packer_ami.json
+++ b/Chapter09/packer/packer_ami.json
@@ -3,21 +3,25 @@
     "aws_access_key": "",
     "aws_secret_key": ""
   },
-  "builders": [{
-    "type": "amazon-ebs",
-    "access_key": "{{user `aws_access_key`}}",
-    "secret_key": "{{user `aws_secret_key`}}",
-    "region": "eu-central-1",
-    "source_ami": "ami-0f1026b68319bad6c",
-    "instance_type": "t2.micro",
-    "ssh_username": "admin",
-    "ami_name": "Project's Base Image {{timestamp}}"
-  }],
-  "provisioners": [{
-    "type": "shell",
-    "inline": [
-      "sudo apt-get update",
-      "sudo apt-get install -y nginx"
-    ]
-  }]
+  "builders": [
+    {
+      "type": "amazon-ebs",
+      "access_key": "{{user `aws_access_key`}}",
+      "secret_key": "{{user `aws_secret_key`}}",
+      "region": "eu-central-1",
+      "source_ami": "ami-0f1026b68319bad6c",
+      "instance_type": "t2.micro",
+      "ssh_username": "admin",
+      "ami_name": "Project's Base Image {{timestamp}}"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [
+        "sudo apt-get update",
+        "sudo apt-get install -y nginx"
+      ]
+    }
+  ]
 }

--- a/Chapter09/packer/packer_ami_provisioner.json
+++ b/Chapter09/packer/packer_ami_provisioner.json
@@ -3,25 +3,31 @@
     "aws_access_key": "",
     "aws_secret_key": ""
   },
-  "builders": [{
-    "type": "amazon-ebs",
-    "access_key": "{{user `aws_access_key`}}",
-    "secret_key": "{{user `aws_secret_key`}}",
-    "region": "eu-central-1",
-    "source_ami": "ami-0f1026b68319bad6c",
-    "instance_type": "t2.micro",
-    "ssh_username": "admin",
-    "ami_name": "Project's Base Image {{timestamp}}"
-  }],
-  "provisioners": [{
-    "type": "ansible",
-    "playbook_file": "./provision.yml",
-    "user": "admin",
-    "host_alias": "baseimage"
-  }],
-  "post-processors": [{
-    "type": "manifest",
-    "output": "manifest.json",
-    "strip_path": true
-  }]
+  "builders": [
+    {
+      "type": "amazon-ebs",
+      "access_key": "{{user `aws_access_key`}}",
+      "secret_key": "{{user `aws_secret_key`}}",
+      "region": "eu-central-1",
+      "source_ami": "ami-0f1026b68319bad6c",
+      "instance_type": "t2.micro",
+      "ssh_username": "admin",
+      "ami_name": "Project's Base Image {{timestamp}}"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "ansible",
+      "playbook_file": "./provision.yml",
+      "user": "admin",
+      "host_alias": "baseimage"
+    }
+  ],
+  "post-processors": [
+    {
+      "type": "manifest",
+      "output": "manifest.json",
+      "strip_path": true
+    }
+  ]
 }

--- a/Chapter10/README.md
+++ b/Chapter10/README.md
@@ -7,8 +7,8 @@ Hands-On Software Architecture with C++ by Packt Publishing
 
 Install the following software:
 - CMake 3.15
-- Conan 1.34.1
-- GCC 10
+- Conan 1.62.0
+- GCC 13
 
 Assuming you're on Linux or using WSL, configure a hosacpp Conan profile and remotes by running:
 
@@ -16,16 +16,16 @@ Assuming you're on Linux or using WSL, configure a hosacpp Conan profile and rem
 conan profile new hosacpp || true
 conan profile update settings.compiler=gcc hosacpp
 conan profile update settings.compiler.libcxx=libstdc++11 hosacpp
-conan profile update settings.compiler.version=10 hosacpp
+conan profile update settings.compiler.version=13 hosacpp
 conan profile update settings.arch=x86_64 hosacpp
 conan profile update settings.os=Linux hosacpp
 ```
 
-If GCC 10 is not your default compiler, you also need to add:
+If GCC 13 is not your default compiler, you also need to add:
 
 ```bash
-conan profile update env.CXX=`which g++-10` hosacpp
-conan profile update env.CC=`which gcc-10` hosacpp
+conan profile update env.CXX=`which g++-13` hosacpp
+conan profile update env.CC=`which gcc-13` hosacpp
 ```
 
 ### Building
@@ -40,9 +40,9 @@ cmake ../mobile_app -DCMAKE_BUILD_TYPE=Release # build type must match Conan's
 cmake --build .
 ```
 
-If GCC 10 is not your default compiler, you can tell CMake to use it with the `CMAKE_CXX_COMPILER` flag.
+If GCC 13 is not your default compiler, you can tell CMake to use it with the `CMAKE_CXX_COMPILER` flag.
 Replace the first invocation above with:
 
 ```bash
-cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=`which g++-10`
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=`which g++-13`
 ```

--- a/Chapter10/README.md
+++ b/Chapter10/README.md
@@ -1,5 +1,5 @@
-# Hands-On-Software-Architecture-with-Cpp
-Hands-On Software Architecture with C++ by Packt Publishing
+# Software Architecture with C++
+Software Architecture with C++ by Packt Publishing
 
 ## Chapter 10: Security in Code and Deployment
 
@@ -10,22 +10,22 @@ Install the following software:
 - Conan 1.62.0
 - GCC 13
 
-Assuming you're on Linux or using WSL, configure a hosacpp Conan profile and remotes by running:
+Assuming you're on Linux or using WSL, configure a sacpp Conan profile and remotes by running:
 
 ```bash
-conan profile new hosacpp || true
-conan profile update settings.compiler=gcc hosacpp
-conan profile update settings.compiler.libcxx=libstdc++11 hosacpp
-conan profile update settings.compiler.version=13 hosacpp
-conan profile update settings.arch=x86_64 hosacpp
-conan profile update settings.os=Linux hosacpp
+conan profile new sacpp || true
+conan profile update settings.compiler=gcc sacpp
+conan profile update settings.compiler.libcxx=libstdc++11 sacpp
+conan profile update settings.compiler.version=13 sacpp
+conan profile update settings.arch=x86_64 sacpp
+conan profile update settings.os=Linux sacpp
 ```
 
 If GCC 13 is not your default compiler, you also need to add:
 
 ```bash
-conan profile update env.CXX=`which g++-13` hosacpp
-conan profile update env.CC=`which gcc-13` hosacpp
+conan profile update env.CXX=`which g++-13` sacpp
+conan profile update env.CC=`which gcc-13` sacpp
 ```
 
 ### Building
@@ -35,7 +35,7 @@ To build the customer project, first cd to its source directory, and then run:
 ```bash
 mkdir build
 cd build
-conan install ../mobile_app --build=missing -s build_type=Release -pr=hosacpp
+conan install ../mobile_app --build=missing -s build_type=Release -pr=sacpp
 cmake ../mobile_app -DCMAKE_BUILD_TYPE=Release # build type must match Conan's
 cmake --build .
 ```

--- a/Chapter10/mobile_app/conanfile.txt
+++ b/Chapter10/mobile_app/conanfile.txt
@@ -1,7 +1,7 @@
 [requires]
-Catch2/2.11.0@catchorg/stable
-trompeloeil/v37@rollbear/stable
-ms-gsl/3.1.0
+Catch2/2.13.10
+trompeloeil/46
+ms-gsl/4.0.0
 
 [generators]
 CMakeDeps

--- a/Chapter11/README.md
+++ b/Chapter11/README.md
@@ -1,5 +1,5 @@
-# Hands-On-Software-Architecture-with-Cpp
-Hands-On Software Architecture with C++ by Packt Publishing
+# Software Architecture with C++
+Software Architecture with C++ by Packt Publishing
 
 ## Chapter 11: Performance
 
@@ -10,22 +10,22 @@ Install the following software:
 - Conan 1.62.0
 - GCC 13
 
-Assuming you're on Linux or using WSL, configure a hosacpp Conan profile and remotes by running:
+Assuming you're on Linux or using WSL, configure a sacpp Conan profile and remotes by running:
 
 ```bash
-conan profile new hosacpp || true
-conan profile update settings.compiler=gcc hosacpp
-conan profile update settings.compiler.libcxx=libstdc++11 hosacpp
-conan profile update settings.compiler.version=13 hosacpp
-conan profile update settings.arch=x86_64 hosacpp
-conan profile update settings.os=Linux hosacpp
+conan profile new sacpp || true
+conan profile update settings.compiler=gcc sacpp
+conan profile update settings.compiler.libcxx=libstdc++11 sacpp
+conan profile update settings.compiler.version=13 sacpp
+conan profile update settings.arch=x86_64 sacpp
+conan profile update settings.os=Linux sacpp
 ```
 
 If GCC 13 is not your default compiler, you also need to add:
 
 ```bash
-conan profile update env.CXX=`which g++-13` hosacpp
-conan profile update env.CC=`which gcc-13` hosacpp
+conan profile update env.CXX=`which g++-13` sacpp
+conan profile update env.CC=`which gcc-13` sacpp
 ```
 
 ### Building
@@ -35,7 +35,7 @@ To build the project, first cd to its directory, and then run:
 ```bash
 mkdir build
 cd build
-conan install .. --build=missing -s build_type=Release -pr=hosacpp
+conan install .. --build=missing -s build_type=Release -pr=sacpp
 cmake .. -DCMAKE_BUILD_TYPE=Release # build type must match Conan's
 cmake --build .
 ```

--- a/Chapter11/README.md
+++ b/Chapter11/README.md
@@ -7,8 +7,8 @@ Hands-On Software Architecture with C++ by Packt Publishing
 
 Install the following software:
 - CMake 3.15
-- Conan 1.34.1
-- GCC 10
+- Conan 1.62.0
+- GCC 13
 
 Assuming you're on Linux or using WSL, configure a hosacpp Conan profile and remotes by running:
 
@@ -16,16 +16,16 @@ Assuming you're on Linux or using WSL, configure a hosacpp Conan profile and rem
 conan profile new hosacpp || true
 conan profile update settings.compiler=gcc hosacpp
 conan profile update settings.compiler.libcxx=libstdc++11 hosacpp
-conan profile update settings.compiler.version=10 hosacpp
+conan profile update settings.compiler.version=13 hosacpp
 conan profile update settings.arch=x86_64 hosacpp
 conan profile update settings.os=Linux hosacpp
 ```
 
-If GCC 10 is not your default compiler, you also need to add:
+If GCC 13 is not your default compiler, you also need to add:
 
 ```bash
-conan profile update env.CXX=`which g++-10` hosacpp
-conan profile update env.CC=`which gcc-10` hosacpp
+conan profile update env.CXX=`which g++-13` hosacpp
+conan profile update env.CC=`which gcc-13` hosacpp
 ```
 
 ### Building
@@ -40,9 +40,9 @@ cmake .. -DCMAKE_BUILD_TYPE=Release # build type must match Conan's
 cmake --build .
 ```
 
-If GCC 10 is not your default compiler, you can tell CMake to use it with the `CMAKE_CXX_COMPILER` flag.
+If GCC 13 is not your default compiler, you can tell CMake to use it with the `CMAKE_CXX_COMPILER` flag.
 Replace the first invocation above with:
 
 ```bash
-cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=`which g++-10`
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=`which g++-13`
 ```

--- a/Chapter11/conanfile.txt
+++ b/Chapter11/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
-benchmark/1.5.2
-fmt/7.1.3
+fmt/10.1.1
+benchmark/1.8.3
 
 [generators]
 CMakeDeps

--- a/Chapter11/coroutines/main_1.cpp
+++ b/Chapter11/coroutines/main_1.cpp
@@ -1,5 +1,6 @@
 #include <fmt/format.h>
 #include <fmt/ostream.h>
+#include <fmt/std.h>
 
 #include <chrono>
 #include <cppcoro/async_mutex.hpp>

--- a/Chapter12/README.md
+++ b/Chapter12/README.md
@@ -7,8 +7,8 @@ Hands-On Software Architecture with C++ by Packt Publishing
 
 Install the following software:
 - CMake 3.15
-- Conan 1.34.1
-- GCC 10
+- Conan 1.62.0
+- GCC 13
 
 Assuming you're on Linux or using WSL, configure a hosacpp Conan profile and remotes by running:
 
@@ -16,16 +16,16 @@ Assuming you're on Linux or using WSL, configure a hosacpp Conan profile and rem
 conan profile new hosacpp || true
 conan profile update settings.compiler=gcc hosacpp
 conan profile update settings.compiler.libcxx=libstdc++11 hosacpp
-conan profile update settings.compiler.version=10 hosacpp
+conan profile update settings.compiler.version=13 hosacpp
 conan profile update settings.arch=x86_64 hosacpp
 conan profile update settings.os=Linux hosacpp
 ```
 
-If GCC 10 is not your default compiler, you also need to add:
+If GCC 13 is not your default compiler, you also need to add:
 
 ```bash
-conan profile update env.CXX=`which g++-10` hosacpp
-conan profile update env.CC=`which gcc-10` hosacpp
+conan profile update env.CXX=`which g++-13` hosacpp
+conan profile update env.CC=`which gcc-13` hosacpp
 ```
 
 Add a Conan remote with AWS C++ SDK:

--- a/Chapter12/README.md
+++ b/Chapter12/README.md
@@ -1,5 +1,5 @@
-# Hands-On-Software-Architecture-with-Cpp
-Hands-On Software Architecture with C++ by Packt Publishing
+# Software Architecture with C++
+Software Architecture with C++ by Packt Publishing
 
 ## Chapter 12: Service Oriented Architecture
 
@@ -10,22 +10,22 @@ Install the following software:
 - Conan 1.62.0
 - GCC 13
 
-Assuming you're on Linux or using WSL, configure a hosacpp Conan profile and remotes by running:
+Assuming you're on Linux or using WSL, configure a sacpp Conan profile and remotes by running:
 
 ```bash
-conan profile new hosacpp || true
-conan profile update settings.compiler=gcc hosacpp
-conan profile update settings.compiler.libcxx=libstdc++11 hosacpp
-conan profile update settings.compiler.version=13 hosacpp
-conan profile update settings.arch=x86_64 hosacpp
-conan profile update settings.os=Linux hosacpp
+conan profile new sacpp || true
+conan profile update settings.compiler=gcc sacpp
+conan profile update settings.compiler.libcxx=libstdc++11 sacpp
+conan profile update settings.compiler.version=13 sacpp
+conan profile update settings.arch=x86_64 sacpp
+conan profile update settings.os=Linux sacpp
 ```
 
 If GCC 13 is not your default compiler, you also need to add:
 
 ```bash
-conan profile update env.CXX=`which g++-13` hosacpp
-conan profile update env.CC=`which gcc-13` hosacpp
+conan profile update env.CXX=`which g++-13` sacpp
+conan profile update env.CC=`which gcc-13` sacpp
 ```
 
 Add a Conan remote with AWS C++ SDK:
@@ -50,7 +50,7 @@ To build the example app, run:
 ```bash
 mkdir build
 cd build
-conan install ../s3 --build=missing -s build_type=Release -pr=hosacpp
+conan install ../s3 --build=missing -s build_type=Release -pr=sacpp
 cmake ../s3 -DCMAKE_BUILD_TYPE=Release # build type must match Conan's
 cmake --build .
 ```

--- a/Chapter12/kubernetes/merchant-manifest.yml
+++ b/Chapter12/kubernetes/merchant-manifest.yml
@@ -1,14 +1,14 @@
-image: hosacpp/merchant:v2.0.3
+image: sacpp/merchant:v2.0.3
 manifests:
-  - image: hosacpp/merchant:v2.0.3-amd64
+  - image: sacpp/merchant:v2.0.3-amd64
     platform:
       architecture: amd64
       os: linux
-  - image: hosacpp/merchant:v2.0.3-arm32
+  - image: sacpp/merchant:v2.0.3-arm32
     platform:
       architecture: arm
       os: linux
-  - image: hosacpp/merchant:v2.0.3-arm64
+  - image: sacpp/merchant:v2.0.3-arm64
     platform:
       architecture: arm64
       os: linux

--- a/Chapter12/packer/packer-digitalocean.json
+++ b/Chapter12/packer/packer-digitalocean.json
@@ -23,7 +23,7 @@
     },
     {
       "type": "shell",
-      "inline":[
+      "inline": [
         "dpkg -i /tmp/{{user `package`}}-{{user `version`}}.deb"
       ]
     }

--- a/Chapter12/rest/openapi.json
+++ b/Chapter12/rest/openapi.json
@@ -24,7 +24,8 @@
               "application/json": {
                 "example": {
                   "itemId": 8,
-                  "name", "Kürtőskalács",
+                  "name",
+                  "Kürtőskalács",
                   "locationId": 5
                 }
               }

--- a/Chapter12/rest/openapi.json
+++ b/Chapter12/rest/openapi.json
@@ -24,8 +24,8 @@
               "application/json": {
                 "example": {
                   "itemId": 8,
-                  "name",
-                  "Kürtőskalács",
+                  "name":
+                      "Kürtőskalács",
                   "locationId": 5
                 }
               }

--- a/Chapter13/CMakeLists.txt
+++ b/Chapter13/CMakeLists.txt
@@ -26,12 +26,10 @@ find_package(grpc REQUIRED)
 find_package(protobuf REQUIRED)
 find_package(Threads REQUIRED)
 
-include(protobuf-generate)
-find_program(GRPC_CPP_PLUGIN grpc_cpp_plugin REQUIRED)
-
 add_library(grpc_service grpc/service.proto)
-target_link_libraries(grpc_service PUBLIC protobuf::libprotobuf gRPC::gRPC)
+target_link_libraries(grpc_service PUBLIC protobuf::libprotobuf gRPC::grpc++)
 
+include(protobuf-generate)
 protobuf_generate(TARGET grpc_service LANGUAGE cpp)
 protobuf_generate(
   TARGET
@@ -42,7 +40,7 @@ protobuf_generate(
   .grpc.pb.h
   .grpc.pb.cc
   PLUGIN
-  "protoc-gen-grpc=${GRPC_CPP_PLUGIN}")
+  "protoc-gen-grpc=\$<TARGET_FILE:gRPC::grpc_cpp_plugin>")
 
 target_include_directories(grpc_service PUBLIC "${CMAKE_CURRENT_BINARY_DIR}")
 

--- a/Chapter13/README.md
+++ b/Chapter13/README.md
@@ -1,5 +1,5 @@
-# Hands-On-Software-Architecture-with-Cpp
-Hands-On Software Architecture with C++ by Packt Publishing
+# Software Architecture with C++
+Software Architecture with C++ by Packt Publishing
 
 ## Chapter 13: Microservices
 
@@ -10,22 +10,22 @@ Install the following software:
 - Conan 1.62.0
 - GCC 13
 
-Assuming you're on Linux or using WSL, configure a hosacpp Conan profile and remotes by running:
+Assuming you're on Linux or using WSL, configure a sacpp Conan profile and remotes by running:
 
 ```bash
-conan profile new hosacpp || true
-conan profile update settings.compiler=gcc hosacpp
-conan profile update settings.compiler.libcxx=libstdc++11 hosacpp
-conan profile update settings.compiler.version=13 hosacpp
-conan profile update settings.arch=x86_64 hosacpp
-conan profile update settings.os=Linux hosacpp
+conan profile new sacpp || true
+conan profile update settings.compiler=gcc sacpp
+conan profile update settings.compiler.libcxx=libstdc++11 sacpp
+conan profile update settings.compiler.version=13 sacpp
+conan profile update settings.arch=x86_64 sacpp
+conan profile update settings.os=Linux sacpp
 ```
 
 If GCC 13 is not your default compiler, you also need to add:
 
 ```bash
-conan profile update env.CXX=`which g++-13` hosacpp
-conan profile update env.CC=`which gcc-13` hosacpp
+conan profile update env.CXX=`which g++-13` sacpp
+conan profile update env.CC=`which gcc-13` sacpp
 ```
 
 ### Building
@@ -35,7 +35,7 @@ To build the example grpc and redis-client applications run:
 ```bash
 mkdir build
 cd build
-conan install .. --build=missing -s build_type=Release -pr=hosacpp
+conan install .. --build=missing -s build_type=Release -pr=sacpp
 cmake .. -DCMAKE_BUILD_TYPE=Release # build type must match Conan's
 cmake --build .
 ```

--- a/Chapter13/README.md
+++ b/Chapter13/README.md
@@ -16,16 +16,16 @@ Assuming you're on Linux or using WSL, configure a hosacpp Conan profile and rem
 conan profile new hosacpp || true
 conan profile update settings.compiler=gcc hosacpp
 conan profile update settings.compiler.libcxx=libstdc++11 hosacpp
-conan profile update settings.compiler.version=10 hosacpp
+conan profile update settings.compiler.version=13 hosacpp
 conan profile update settings.arch=x86_64 hosacpp
 conan profile update settings.os=Linux hosacpp
 ```
 
-If GCC 10 is not your default compiler, you also need to add:
+If GCC 13 is not your default compiler, you also need to add:
 
 ```bash
-conan profile update env.CXX=`which g++-10` hosacpp
-conan profile update env.CC=`which gcc-10` hosacpp
+conan profile update env.CXX=`which g++-13` hosacpp
+conan profile update env.CC=`which gcc-13` hosacpp
 ```
 
 ### Building
@@ -40,9 +40,9 @@ cmake .. -DCMAKE_BUILD_TYPE=Release # build type must match Conan's
 cmake --build .
 ```
 
-If GCC 10 is not your default compiler, you can tell CMake to use it with the `CMAKE_CXX_COMPILER` flag.
+If GCC 13 is not your default compiler, you can tell CMake to use it with the `CMAKE_CXX_COMPILER` flag.
 Replace the first invocation above with:
 
 ```bash
-cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=`which g++-10`
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=`which g++-13`
 ```

--- a/Chapter13/README.md
+++ b/Chapter13/README.md
@@ -6,9 +6,9 @@ Hands-On Software Architecture with C++ by Packt Publishing
 ### Prerequisites
 
 Install the following software:
-- CMake 3.15
-- Conan 1.34.1
-- GCC 10
+- CMake 3.27.9
+- Conan 1.62.0
+- GCC 13
 
 Assuming you're on Linux or using WSL, configure a hosacpp Conan profile and remotes by running:
 

--- a/Chapter13/conanfile.txt
+++ b/Chapter13/conanfile.txt
@@ -1,7 +1,8 @@
 [requires]
-boost/1.75.0
-grpc/1.37.1
-protobuf/3.13.0
+boost/1.83.0
+grpc/1.54.3
+protobuf/3.21.12
+zlib/1.3
 
 [generators]
 CMakeDeps

--- a/Chapter13/grpc/service.proto
+++ b/Chapter13/grpc/service.proto
@@ -1,13 +1,13 @@
 syntax = "proto3";
 
 service Greeter {
- rpc Greet(GreetRequest) returns (GreetResponse);
+  rpc Greet(GreetRequest) returns (GreetResponse);
 }
 
 message GreetRequest {
- string name = 1;
+  string name = 1;
 }
 
 message GreetResponse {
- string reply = 1;
+  string reply = 1;
 }

--- a/Chapter14/README.md
+++ b/Chapter14/README.md
@@ -1,5 +1,5 @@
-# Hands-On-Software-Architecture-with-Cpp
-Hands-On Software Architecture with C++ by Packt Publishing
+# Software Architecture with C++
+Software Architecture with C++ by Packt Publishing
 
 ## Chapter 14: Containers
 
@@ -33,7 +33,7 @@ the working directory.
 To build a static binary, you may use:
 
 ```
-conan install .. --build=missing -s build_type=Release -pr=hosacpp
+conan install .. --build=missing -s build_type=Release -pr=sacpp
 cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXE_LINKER_FLAGS="-static" -DBUILD_SHARED_LIBS=OFF -DCMAKE_FIND_LIBRARY_SUFFIXES=".a"
 cmake --build .
 ```

--- a/Chapter14/containers/docker/compile.Dockerfile
+++ b/Chapter14/containers/docker/compile.Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:latest
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential gcc cmake git googletest python3-pip && \
-    pip3 install conan && conan profile new hosacpp --detect && \
-    conan profile update settings.compiler.libcxx=libstdc++11 hosacpp
+    pip3 install conan && conan profile new sacpp --detect && \
+    conan profile update settings.compiler.libcxx=libstdc++11 sacpp
 
 ADD . /usr/src
 
@@ -10,7 +10,7 @@ WORKDIR /usr/src
 
 RUN mkdir build && \
     cd build && \
-    conan install .. --build=missing -s build_type=Release -pr=hosacpp && \
+    conan install .. --build=missing -s build_type=Release -pr=sacpp && \
     cmake .. -DCMAKE_BUILD_TYPE=Release && \
     cmake --build . && \
     cmake --install .

--- a/Chapter14/containers/docker/multi-stage.Dockerfile
+++ b/Chapter14/containers/docker/multi-stage.Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:latest AS builder
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential gcc cmake git googletest python3-pip && \
-    pip3 install conan && conan profile new hosacpp --detect && \
-    conan profile update settings.compiler.libcxx=libstdc++11 hosacpp
+    pip3 install conan && conan profile new sacpp --detect && \
+    conan profile update settings.compiler.libcxx=libstdc++11 sacpp
 
 ADD . /usr/src
 
@@ -10,7 +10,7 @@ WORKDIR /usr/src
 
 RUN mkdir build && \
     cd build && \
-    conan install .. --build=missing -s build_type=Release -pr=hosacpp && \
+    conan install .. --build=missing -s build_type=Release -pr=sacpp && \
     cmake .. -DCMAKE_BUILD_TYPE=Release && \
     cmake --build .
 

--- a/Chapter14/orchestration/docker-compose/docker-compose.yml
+++ b/Chapter14/orchestration/docker-compose/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     depends_on:
       - merchant
   merchant:
-    image: hosacpp/merchant:v2.0.3
+    image: sacpp/merchant:v2.0.3
     deploy:
       replicas: 3
     ports:

--- a/Chapter14/orchestration/kubernetes/merchant.yaml
+++ b/Chapter14/orchestration/kubernetes/merchant.yaml
@@ -57,7 +57,7 @@ spec:
       containers:
         - name: merchant
           imagePullPolicy: Always
-          image: hosacpp/merchant:v2.0.3
+          image: sacpp/merchant:v2.0.3
           ports:
             - name: http
               containerPort: 8000

--- a/Chapter14/orchestration/nomad/merchant.nomad
+++ b/Chapter14/orchestration/nomad/merchant.nomad
@@ -6,7 +6,7 @@ job "merchant" {
     task "merchant" {
       driver = "docker"
       config {
-        image = "hosacpp/merchant:v2.0.3"
+        image = "sacpp/merchant:v2.0.3"
         port_map {
           http = 8000
         }

--- a/Chapter15/README.md
+++ b/Chapter15/README.md
@@ -7,8 +7,8 @@ Hands-On Software Architecture with C++ by Packt Publishing
 
 Install the following software:
 - CMake 3.15
-- Conan 1.34.1
-- GCC 10
+- Conan 1.62.0
+- GCC 13
 
 Assuming you're on Linux or using WSL, configure a hosacpp Conan profile and remotes by running:
 
@@ -16,16 +16,16 @@ Assuming you're on Linux or using WSL, configure a hosacpp Conan profile and rem
 conan profile new hosacpp || true
 conan profile update settings.compiler=gcc hosacpp
 conan profile update settings.compiler.libcxx=libstdc++11 hosacpp
-conan profile update settings.compiler.version=10 hosacpp
+conan profile update settings.compiler.version=13 hosacpp
 conan profile update settings.arch=x86_64 hosacpp
 conan profile update settings.os=Linux hosacpp
 ```
 
-If GCC 10 is not your default compiler, you also need to add:
+If GCC 13 is not your default compiler, you also need to add:
 
 ```bash
-conan profile update env.CXX=`which g++-10` hosacpp
-conan profile update env.CC=`which gcc-10` hosacpp
+conan profile update env.CXX=`which g++-13` hosacpp
+conan profile update env.CC=`which gcc-13` hosacpp
 ```
 
 ### Building
@@ -40,9 +40,9 @@ cmake ../customer -DCMAKE_BUILD_TYPE=Release # build type must match Conan's
 cmake --build .
 ```
 
-If GCC 10 is not your default compiler, you can tell CMake to use it with the `CMAKE_CXX_COMPILER` flag.
+If GCC 13 is not your default compiler, you can tell CMake to use it with the `CMAKE_CXX_COMPILER` flag.
 Replace the first invocation above with:
 
 ```bash
-cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=`which g++-10`
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=`which g++-13`
 ```

--- a/Chapter15/README.md
+++ b/Chapter15/README.md
@@ -1,5 +1,5 @@
-# Hands-On-Software-Architecture-with-Cpp
-Hands-On Software Architecture with C++ by Packt Publishing
+# Software Architecture with C++
+Software Architecture with C++ by Packt Publishing
 
 ## Chapter 15: Cloud Native Design
 
@@ -10,22 +10,22 @@ Install the following software:
 - Conan 1.62.0
 - GCC 13
 
-Assuming you're on Linux or using WSL, configure a hosacpp Conan profile and remotes by running:
+Assuming you're on Linux or using WSL, configure a sacpp Conan profile and remotes by running:
 
 ```bash
-conan profile new hosacpp || true
-conan profile update settings.compiler=gcc hosacpp
-conan profile update settings.compiler.libcxx=libstdc++11 hosacpp
-conan profile update settings.compiler.version=13 hosacpp
-conan profile update settings.arch=x86_64 hosacpp
-conan profile update settings.os=Linux hosacpp
+conan profile new sacpp || true
+conan profile update settings.compiler=gcc sacpp
+conan profile update settings.compiler.libcxx=libstdc++11 sacpp
+conan profile update settings.compiler.version=13 sacpp
+conan profile update settings.arch=x86_64 sacpp
+conan profile update settings.os=Linux sacpp
 ```
 
 If GCC 13 is not your default compiler, you also need to add:
 
 ```bash
-conan profile update env.CXX=`which g++-13` hosacpp
-conan profile update env.CC=`which gcc-13` hosacpp
+conan profile update env.CXX=`which g++-13` sacpp
+conan profile update env.CC=`which gcc-13` sacpp
 ```
 
 ### Building
@@ -35,7 +35,7 @@ To build the example jaeger-tracing application run:
 ```bash
 mkdir build
 cd build
-conan install ../customer --build=missing -s build_type=Release -pr=hosacpp
+conan install ../customer --build=missing -s build_type=Release -pr=sacpp
 cmake ../customer -DCMAKE_BUILD_TYPE=Release # build type must match Conan's
 cmake --build .
 ```

--- a/Chapter15/customer/README.md
+++ b/Chapter15/customer/README.md
@@ -1,5 +1,5 @@
-# Hands-On-Software-Architecture-with-Cpp
-Hands-On Software Architecture with C++ by Packt Publishing
+# Software Architecture with C++
+Software Architecture with C++ by Packt Publishing
 
 For building instructions, refer to the README file in the root of this chapter's code.
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ You need at least one of the following compilers:
 | No. | Software required | OS required |
 | --- | ----------------- | ----------- |
 |  1  | Microsoft Visual C++ 16.8 | Windows |
-|  2  | Clang 8 / Apple Clang 10 | Windows, Mac OS X, and Linux (Any) |
-|  3  | GCC 11 | Windows, Mac OS X, and Linux (Any) |
+|  2  | Clang 16 | Windows, Mac OS X, and Linux (Any) |
+|  3  | GCC 13 | Windows, Mac OS X, and Linux (Any) |
 
 We also provide a PDF file that has color images of the screenshots/diagrams used in this book. [Click here to download it](https://static.packt-cdn.com/downloads/9781838554590_ColorImages.pdf).
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 
 
 
-# Hands-On-Software-Architecture-with-Cpp
-Hands-On Software Architecture with C++ by Packt Publishing
+# Software Architecture with C++
+Software Architecture with C++ by Packt Publishing
 
 ## Table of Contents
 

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
 { pkgs ? import (
   builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/21.11-pre.tar.gz";
-    sha256 = "0ww19c7n4fj9zn770aw8zaqld742bi9sa9s8hqb3vrgp3mpihil0";
+    url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/24.05-pre.tar.gz";
+    sha256 = "1cfbkahcfj1hgh4v5nfqwivg69zks8d72n11m5513i0phkqwqcgh";
   }
 ) {} }:
 
@@ -9,8 +9,8 @@ let
   additionalInputs = if pkgs.system == "x86_64-linux" then pkgs.lsb-release else "";
 in
 with pkgs; {
-  gcc11Env = stdenvNoCC.mkDerivation {
-    name = "gcc11-environment";
+  gcc13Env = stdenvNoCC.mkDerivation {
+    name = "gcc13-environment";
     buildInputs = [
       autoconf
       automake
@@ -20,7 +20,7 @@ with pkgs; {
       docker
       docker-compose
       doxygen
-      gcc11
+      gcc13
       libtool
       pkg-config
       pre-commit


### PR DESCRIPTION
* Bump GCC to 13 as the current leading one.
* Update Nix to a version providing this GCC version. NB: this version
still misses CMake 3.28 (with modules support) so we'll have to update
once more.
* Update Conan to latest 1.x and update package versions to available
ones. NB: We plan to upgrade to Conan 2 soon.
* Update used libraries and tools to stay up to date and build cleanly.
* Update README to reflect all those changes
* Finish renaming to Software Architecture with C++